### PR TITLE
EducatorPreparationPrograms & Candidates - Updated schema version

### DIFF
--- a/Samples/Sample XML/EXTENSION-Interchange-EducationOrganization-Extension.xml
+++ b/Samples/Sample XML/EXTENSION-Interchange-EducationOrganization-Extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<InterchangeEducationOrganization xmlns:ann="http://ed-fi.org/annotation" xmlns="http://ed-fi.org/3.3.0-a">
+<InterchangeEducationOrganization xmlns:ann="http://ed-fi.org/annotation" xmlns="http://ed-fi.org/3.3.1-b">
 	<EducatorPreparationProgram>
 		<EducationOrganizationReference>
 			<EducationOrganizationIdentity>


### PR DESCRIPTION
Removed StudentAcademicRecord and CourseTranscript from sample data - It would have required supporting more descriptors and is not used with the starter kits + is tested by core sample data